### PR TITLE
fix: jwt verify 동기식에서 비동기식으로 변환

### DIFF
--- a/middlewares/userAuthChecker.js
+++ b/middlewares/userAuthChecker.js
@@ -1,38 +1,53 @@
-const { BadRequestError, ForbiddenError, UnauthorizedError } = require("../errors/httpErrors");
+const {
+  BadRequestError,
+  ForbiddenError,
+  UnauthorizedError,
+} = require("../errors/httpErrors");
 const UserModel = require("../model/index");
+
 const { jwtConfig } = require("../config/config");
 const jwt = require("jsonwebtoken");
+const { promisify } = require("util");
+
+const jwtVerify = promisify(jwt.verify);
 
 /**
  * jwt.verify 오류 처리를 위해 분리한 함수
  * @param {string} token jwt 토큰을 받아옵니다.
  * @returns {int}
  */
-const verify = (token) => {
+const verify = async (token) => {
   try {
-    const decoded = jwt.verify(token, jwtConfig.secretKey, jwtConfig.option);
-    return decoded;
+    return await jwtVerify(token, jwtConfig.secretKey, jwtConfig.option);
   } catch (err) {
     if (err.message === "jwt expired") {
-        throw new UnauthorizedError("Jwt token is expired");
-    } else if (err.message === 'jwt signature is required') {
-        throw new UnauthorizedError("Jwt signature is required");
-    } else if (err.message === 'jwt malformed') {
-        throw new UnauthorizedError("Jwt verify function does not have three components");
-    } else if (err.message === 'invalid signature') {
-        throw new UnauthorizedError("Jwt Signature is invalid");
-    } else if (err.message === 'jwt audience invalid. expected: [OPTIONS AUDIENCE]') {
-        throw new UnauthorizedError("Jwt Audience is invalid");
-    } else if (err.message === 'jwt id invalid. expected: [OPTIONS JWT ID]') {
-        throw new UnauthorizedError("Jwt id is invalid");
-    } else if (err.message === 'jwt issuer invalid. expected: [OPTIONS ISSUER]') {
-        throw new UnauthorizedError("Jwt issuer is invalid");
-    } else if (err.message === 'jwt subject invalid. expected: [OPTIONS SUBJECT]') {
-        throw new UnauthorizedError("Jwt subject is invalid");
-    } else if (err.message === 'jwt not active') {
-        throw new UnauthorizedError("Jwt is not active");
-    } else (err.message === 'invalid token') {
-        throw new UnauthorizedError("Jwt token is invalid");
+      throw new UnauthorizedError("Jwt token is expired");
+    } else if (err.message === "jwt signature is required") {
+      throw new UnauthorizedError("Jwt signature is required");
+    } else if (err.message === "jwt malformed") {
+      throw new UnauthorizedError(
+        "Jwt verify function does not have three components"
+      );
+    } else if (err.message === "invalid signature") {
+      throw new UnauthorizedError("Jwt Signature is invalid");
+    } else if (
+      err.message === "jwt audience invalid. expected: [OPTIONS AUDIENCE]"
+    ) {
+      throw new UnauthorizedError("Jwt Audience is invalid");
+    } else if (err.message === "jwt id invalid. expected: [OPTIONS JWT ID]") {
+      throw new UnauthorizedError("Jwt id is invalid");
+    } else if (
+      err.message === "jwt issuer invalid. expected: [OPTIONS ISSUER]"
+    ) {
+      throw new UnauthorizedError("Jwt issuer is invalid");
+    } else if (
+      err.message === "jwt subject invalid. expected: [OPTIONS SUBJECT]"
+    ) {
+      throw new UnauthorizedError("Jwt subject is invalid");
+    } else if (err.message === "jwt not active") {
+      throw new UnauthorizedError("Jwt is not active");
+    } else {
+      throw new UnauthorizedError("Jwt token is invalid");
     }
   }
 };
@@ -50,7 +65,7 @@ const userAuthChecker = (roles) => {
       if (!userInfo) {
         throw new BadRequestError(`Can't find user`);
       }
-      if (!roles.includes(user.role)) {
+      if (!roles.includes(userInfo.role)) {
         throw new ForbiddenError(`User doesn't have authorization`);
       }
       req.userInfo = userInfo;


### PR DESCRIPTION
# jwt verify 동기식에서 비동기식으로 변환

## 왜 비동기식을 사용하는 것이 좋나요?
- nodejs는 기본적으로 싱글 쓰레드이고 동기식을 작성하면 동기식이 끝될 때까지 요청된 다른 작업이 기다려야 하는 문제가 생깁니다. 예를 들어서, API에서 10,000건의 요청이 들어온다면 3ms가 걸리더라도 30초가 걸리기 때문에 API 퍼포먼스에 치명적입니다.
- 따라서 동기식이 꼭 필요한 경우가 아니라면 지양하는 것이 서버 퍼포먼스를 고려했을 때 좋습니다.

## 기존의 jwt verify 작동 방식 (동기식)
- 원래 jwt verify는 네번째 인자에 콜백 함수 또는 넣어주어야 비동기식으로 작동하기 때문에 await을 사용해도 비동기식이 아닌 jwt verify에 await이 작동하지 않았습니다.
![image](https://user-images.githubusercontent.com/30682847/188370428-402d44d9-9ac0-428e-9c03-ea56d45578fc.png)

## 적용된 jwt verify 작동 방식 (비동기식)
- 따라서, await 비동기식으로 적용하기 위해서는 아래와 같이 코드를 작성했어야 합니다.
![image](https://user-images.githubusercontent.com/30682847/188373968-53a10736-0867-45ef-ba7a-0ba394b0bcd9.png)
- promisify를 이용해 Promise 클래스로 감싸주지 않고도 동일한 기능을 하는 코드를 작성했습니다.
![image](https://user-images.githubusercontent.com/30682847/188374303-44f7e462-66b5-4165-8da5-981731d717b4.png)


- user.role은 없기 때문에 userInfo.role로 변환하였습니다.
- 마지막 else if 문(token invalid 부분)이 else로 끝나야 하는 부분이라 else로 수정하였습니다.

위에 명시되지 않은 작업은 하지 않았으며, 확인 후 리뷰 남겨주시면 감사하겠습니다 😊